### PR TITLE
Add dev container setup script

### DIFF
--- a/setup_dev_container.sh
+++ b/setup_dev_container.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build and run a Docker container for local development
+set -e
+IMAGE_NAME="hcf-website-dev"
+
+echo "Checking for Docker..."
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but not installed." >&2
+  exit 1
+fi
+
+echo "Building development image..."
+docker build -t "$IMAGE_NAME" -f- . <<'DOCKER'
+FROM node:18
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev"]
+DOCKER
+
+echo "Starting development container..."
+docker run --rm -it -p 3000:3000 -v "$(pwd)":/app -v hcf_node_modules:/app/node_modules "$IMAGE_NAME"
+

--- a/setup_dev_container.sh
+++ b/setup_dev_container.sh
@@ -10,6 +10,14 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 echo "Building development image..."
+echo "Creating .dockerignore file..."
+cat > .dockerignore <<'EOF'
+.git/
+node_modules/
+*.log
+Dockerfile
+.dockerignore
+EOF
 docker build -t "$IMAGE_NAME" -f- . <<'DOCKER'
 FROM node:18
 WORKDIR /app


### PR DESCRIPTION
## Summary
- add `setup_dev_container.sh` for building and running a Docker-based dev environment

## Testing
- `bash -n setup_dev_container.sh`


------
https://chatgpt.com/codex/tasks/task_e_685099de97b48326ab456a0f360daa5f