### PR TITLE
Add Formspree feedback widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern, statically generated website for the Hillsdale Community Foundation bu
 - **Blog System**: Markdown-based blog posts with front matter support
 - **Google Calendar Integration**: Embedded calendar showing upcoming events
 - **Custom Domain**: Configured for deployment to `www.hillsdalecommunityfoundation.org`
+- **Feedback Widget**: Easy reporting of website issues via Formspree
 
 ## 🚀 Quick Start
 
@@ -210,6 +211,7 @@ This project is licensed under the MIT License.
 For support and questions:
 - Create an issue in the GitHub repository
 - Contact the Hillsdale Community Foundation
+- Use the website Feedback button to report issues or requests
 
 ---
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import Footer from "@/app/_components/footer";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Navigation from "@/app/_components/navigation";
+import Script from "next/script";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -26,6 +27,27 @@ export default function RootLayout({
         <Navigation />
         <div className="min-h-screen">{children}</div>
         <Footer />
+        <Script src="https://formspree.io/js/formbutton-v1.min.js" strategy="afterInteractive" />
+        <Script id="feedback-widget" strategy="afterInteractive">
+          {`
+            window.formbutton = window.formbutton || function(){(formbutton.q = formbutton.q || []).push(arguments);};
+            formbutton("create", {
+              action: "https://formspree.io/f/your-form-id",
+              title: "Website Feedback",
+              description: "Found a problem or have a request? Let us know!",
+              fields: [
+                { type: "text", name: "name", label: "Name" },
+                { type: "email", name: "email", label: "Email (optional)" },
+                { type: "textarea", name: "message", label: "Feedback", required: true },
+                { type: "submit" }
+              ],
+              styles: {
+                title: { backgroundColor: "#2563eb" },
+                button: { backgroundColor: "#2563eb" }
+              }
+            });
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add Formspree floating feedback form via `formbutton` script
- highlight feedback widget in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854506e75808326acad3d267bf68fbf