### PR TITLE
Add floating feedback/contact button to all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern, statically generated website for the Hillsdale Community Foundation bu
 - **Blog System**: Markdown-based blog posts with front matter support
 - **Google Calendar Integration**: Embedded calendar showing upcoming events
 - **Custom Domain**: Configured for deployment to `www.hillsdalecommunityfoundation.org`
+- **Feedback Widget**: Easy reporting of website issues via Formspree
 
 ## 🚀 Quick Start
 
@@ -210,6 +211,7 @@ This project is licensed under the MIT License.
 For support and questions:
 - Create an issue in the GitHub repository
 - Contact the Hillsdale Community Foundation
+- Use the website Feedback button to report issues or requests
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "site-demo",
+  "name": "website",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,17 +32,15 @@ export default function RootLayout({
           {`
             window.formbutton = window.formbutton || function(){(formbutton.q = formbutton.q || []).push(arguments);};
             formbutton("create", {
-              action: "https://formspree.io/f/your-form-id",
-              title: "Website Feedback",
-              description: "Found a problem or have a request? Let us know!",
+              action: "https://formspree.io/f/mblyynrw",
+              title: "How can we help?",
               fields: [
-                { type: "text", name: "name", label: "Name" },
-                { type: "email", name: "email", label: "Email (optional)" },
-                { type: "textarea", name: "message", label: "Feedback", required: true },
+                { type: "email", label: "Email:", name: "email", required: true, placeholder: "your@email.com" },
+                { type: "textarea", label: "Message:", name: "message", placeholder: "What's on your mind?" },
                 { type: "submit" }
               ],
               styles: {
-                title: { backgroundColor: "#2563eb" },
+                title: { backgroundColor: "gray" },
                 button: { backgroundColor: "#2563eb" }
               }
             });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import Footer from "@/app/_components/footer";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Navigation from "@/app/_components/navigation";
+import Script from "next/script";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -26,6 +27,27 @@ export default function RootLayout({
         <Navigation />
         <div className="min-h-screen">{children}</div>
         <Footer />
+        <Script src="https://formspree.io/js/formbutton-v1.min.js" strategy="afterInteractive" />
+        <Script id="feedback-widget" strategy="afterInteractive">
+          {`
+            window.formbutton = window.formbutton || function(){(formbutton.q = formbutton.q || []).push(arguments);};
+            formbutton("create", {
+              action: "https://formspree.io/f/your-form-id",
+              title: "Website Feedback",
+              description: "Found a problem or have a request? Let us know!",
+              fields: [
+                { type: "text", name: "name", label: "Name" },
+                { type: "email", name: "email", label: "Email (optional)" },
+                { type: "textarea", name: "message", label: "Feedback", required: true },
+                { type: "submit" }
+              ],
+              styles: {
+                title: { backgroundColor: "#2563eb" },
+                button: { backgroundColor: "#2563eb" }
+              }
+            });
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
This PR adds a floating feedback button to the site using Formspree's formbutton widget.

- The button appears on all pages (configured in src/app/layout.tsx)
- Clicking the button opens a simple feedback/contact form (email + message)
- Submissions go to Formspree for easy management
- Button color matches the site's donate button for consistent branding

This provides a quick, accessible way for visitors to send feedback or contact the Foundation from anywhere on the site.

No changes to the existing full-page contact form.

Ready for review and merge.