### PR TITLE
Centralize footer address

### DIFF
--- a/src/app/_components/footer.tsx
+++ b/src/app/_components/footer.tsx
@@ -1,4 +1,5 @@
 import Container from "@/app/_components/container";
+import { FOUNDATION_ADDRESS } from "@/lib/constants";
 
 export function Footer() {
   return (
@@ -6,9 +7,7 @@ export function Footer() {
       <Container>
         <div className="py-12 flex flex-col items-center">
           <h3 className="text-2xl font-bold mb-4">Contact Us</h3>
-          <p className="mb-2">Hillsdale Community Foundation</p>
-          <p className="mb-2">P.O. Box 82995</p>
-          <p className="mb-6">Portland, OR 97282</p>
+          <p className="mb-6 whitespace-pre-line text-center">{FOUNDATION_ADDRESS}</p>
           <div className="flex space-x-4">
             <a href="/get-involved" className="text-white hover:text-hillsdale-yellow">Get Involved</a>
             <a href="/donate" className="text-white hover:text-hillsdale-yellow">Donate</a>


### PR DESCRIPTION
## Summary
- use centralized FOUNDATION_ADDRESS constant in footer
- audit repo for hard-coded addresses

## Testing
- `npm run typecheck` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685ad67a781c832682f0d2d8a9fc1530